### PR TITLE
debian: populate DISTRIBUTION variable

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -1,6 +1,7 @@
 #!/usr/bin/make -f
 
 VERSION = 0.$(shell date +%F)
+DISTRIBUTION = $(shell lsb_release -sc)
 PACKAGEVERSION = $(VERSION)-0~$(DISTRIBUTION)0
 
 %:


### PR DESCRIPTION
In turn, populate distribution codename to package version. This
is helpful in cases we'd like to avoid package name conflict between
distributions, call me aptly.