### PR TITLE
Add lsb-release as build dependency

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -1,6 +1,6 @@
 Source: pynfdump-riemann-alerter
 Maintainer: Vincent Bernat <bernat@debian.org>
-Build-Depends: debhelper (>= 9)
+Build-Depends: debhelper (>= 9), lsb-release
 
 Package: pynfdump-riemann-alerter
 Architecture: all


### PR DESCRIPTION
Without it DISTRIBUTION variable would not evaluate during build
since lsb_release command would not be found.